### PR TITLE
fix func (j *Job) Run() defer order

### DIFF
--- a/jobrunner.go
+++ b/jobrunner.go
@@ -69,8 +69,8 @@ func (j *Job) Run() {
 	atomic.StoreUint32(&j.status, 1)
 	j.StatusUpdate()
 
-	defer atomic.StoreUint32(&j.status, 0)
 	defer j.StatusUpdate()
+	defer atomic.StoreUint32(&j.status, 0)
 
 	j.inner.Run()
 


### PR DESCRIPTION
This PR fix func (j *Job) Run()  defer order so job status is correctly updated.