### PR TITLE
Use go modules to manage dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+.idea
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ JobRunner is designed to be framework agnostic. So it will work with pure Go app
 
 ## Credits
 - [revel jobs module](https://github.com/revel/modules/tree/master/jobs) - Origin of JobRunner
-- [robfig cron v2](https://github.com/robfig/cron/tree/v2) - gopkg.in/robfig/cron.v2
+- [robfig cron v3](https://github.com/robfig/cron/tree/v3) - github.com/robfig/cron/v3
 - [contributors](https://github.com/bamzi/jobrunner/graphs/contributors)
 
 ### Author 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/bamzi/jobrunner
+
+go 1.13
+
+require github.com/robfig/cron/v3 v3.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/robfig/cron/v3 v3.0.0 h1:kQ6Cb7aHOHTSzNVNEhmp8EcWKLb4CbiMW9h9VyIhO4E=
+github.com/robfig/cron/v3 v3.0.0/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=

--- a/init.go
+++ b/init.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"gopkg.in/robfig/cron.v3"
+	"github.com/robfig/cron/v3"
 )
 
 const DEFAULT_JOB_POOL_SIZE = 10

--- a/jobrunner.go
+++ b/jobrunner.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"gopkg.in/robfig/cron.v3"
+	"github.com/robfig/cron/v3"
 )
 
 type Job struct {

--- a/runjob.go
+++ b/runjob.go
@@ -13,7 +13,7 @@ package jobrunner
 import (
 	"time"
 
-	"gopkg.in/robfig/cron.v3"
+	"github.com/robfig/cron/v3"
 )
 
 // Callers can use jobs.Func to wrap a raw func.

--- a/status.go
+++ b/status.go
@@ -3,7 +3,7 @@ package jobrunner
 import (
 	"time"
 
-	"gopkg.in/robfig/cron.v3"
+	"github.com/robfig/cron/v3"
 )
 
 type StatusData struct {

--- a/stopjob.go
+++ b/stopjob.go
@@ -1,6 +1,6 @@
 package jobrunner
 
-import "gopkg.in/robfig/cron.v3"
+import "github.com/robfig/cron/v3"
 
 // Stop ALL active jobs from running at the next scheduled time
 func Stop() {


### PR DESCRIPTION
As go modules has become the defacto standard for managing dependencies. Cron has moved to using go modules, gopkg,in support removed.

More information about cron update can be found here.
https://github.com/robfig/cron#upgrading-to-v3-june-2019

This will solve issue #17 

