### PR TITLE
Use std logger to allow override output

### DIFF
--- a/init.go
+++ b/init.go
@@ -1,7 +1,7 @@
 package jobrunner
 
 import (
-	"fmt"
+	"log"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -25,19 +25,19 @@ var (
 	magenta = string([]byte{27, 91, 57, 55, 59, 52, 53, 109})
 	reset   = string([]byte{27, 91, 48, 109})
 
-	functions =[]interface{}{makeWorkPermits,isSelfConcurrent}
+	functions = []interface{}{makeWorkPermits, isSelfConcurrent}
 )
 
 func makeWorkPermits(bufferCapacity int) {
-	if bufferCapacity <=0 {
+	if bufferCapacity <= 0 {
 		workPermits = make(chan struct{}, DEFAULT_JOB_POOL_SIZE)
 	} else {
 		workPermits = make(chan struct{}, bufferCapacity)
 	}
 }
 
-func isSelfConcurrent(cocnurrencyFlag int) {
-	if cocnurrencyFlag <=0 {
+func isSelfConcurrent(concurrencyFlag int) {
+	if concurrencyFlag <= 0 {
 		selfConcurrent = false
 	} else {
 		selfConcurrent = true
@@ -47,14 +47,13 @@ func isSelfConcurrent(cocnurrencyFlag int) {
 func Start(v ...int) {
 	MainCron = cron.New()
 
-	for i,option := range v {
+	for i, option := range v {
 		functions[i].(func(int))(option)
 	}
 
-
 	MainCron.Start()
 
-	fmt.Printf("%s[JobRunner] %v Started... %s \n",
+	log.Printf("%s[JobRunner] %v Started... %s \n",
 		magenta, time.Now().Format("2006/01/02 - 15:04:05"), reset)
 
 }

--- a/jobrunner.go
+++ b/jobrunner.go
@@ -1,7 +1,6 @@
 package jobrunner
 
 import (
-	"bytes"
 	"log"
 	"reflect"
 	"runtime/debug"
@@ -50,9 +49,8 @@ func (j *Job) Run() {
 	// Don't let the whole process die.
 	defer func() {
 		if err := recover(); err != nil {
-			var buf bytes.Buffer
-			logger := log.New(&buf, "JobRunner Log: ", log.Lshortfile)
-			logger.Panic(err, "\n", string(debug.Stack()))
+			log.Printf("[JobRunner] %v Job %q Panicked:\n%s\n",
+				time.Now().Format("2006/01/02 - 15:04:05"), j.Name, string(debug.Stack()))
 		}
 	}()
 


### PR DESCRIPTION
This PR changes output for the application flow logs from direct write to `os.Stdout` (`fmt.Print`) to stdlib `log` that allows to override real output with the existing log writer. E.g.

```go
imprt (
  "log"
  "go.uber.org/zap"
)

// implements io.Writer to write logs to app logger instead of default os.Stderr
type stdLoggerWriter struct {
	logger *zap.Logger
}

func (w *stdLoggerWriter) Write(p []byte) (int, error) {
	w.logger.Info(string(p), zap.String("source", "std-log"))
	return len(p), nil
}

logger, _ := zap.NewDevelopment()

// override std logger to write into app logger
log.SetOutput(&stdLoggerWriter{logger})
```